### PR TITLE
qpp: add macOS architecture-specific releases

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -1,8 +1,18 @@
 class Qpp < Formula
   desc "Q++: quantum–classical compiler and simulator"
   homepage "https://github.com/sefunmi4/qpp-gcc"
-  url "https://github.com/sefunmi4/qpp-gcc/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "shasum -a 256 qpp-0.2.0.tar.gz"
+  on_macos do
+    on_intel do
+      url "https://github.com/sefunmi4/qpp-gcc/releases/download/v0.2.0/qpp-0.2.0-macos-x64.gz"
+      sha256 "6ab0e3646c723191ab043fb0eb039daa0fa92415bc512d7270c9bd0693f86002"
+    end
+
+    on_arm do
+      url "https://github.com/sefunmi4/qpp-gcc/releases/download/v0.2.0/qpp-0.2.0-macos-arm64.gz"
+      sha256 "9a78e40c2960c72d0dc8d8f66164eab5fc8fc1fb1e0d0ee88491e2047f9a9a10"
+    end
+  end
+
   license "Apache-2.0"
 
   depends_on "cmake" => :build


### PR DESCRIPTION
## Summary
- use macOS release archives for Intel and ARM

## Testing
- `brew audit --strict Formula/qpp.rb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5953ed9a8832fa1ef242e135b2b09