### PR TITLE
qpp: simplify install

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -15,12 +15,8 @@ class Qpp < Formula
 
   license "Apache-2.0"
 
-  depends_on "cmake" => :build
-
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Release"
-    system "cmake", "--build", "build", "--config", "Release", "--parallel"
-    system "cmake", "--install", "build", "--prefix", prefix
+    bin.install "qpp"
   end
 
   test do


### PR DESCRIPTION
## Summary
- drop CMake build dependency and installation steps
- install prebuilt `qpp` binary directly

## Testing
- `ruby -c Formula/qpp.rb`
- `brew --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c596496a30832f91180d8619a0af21