### PR TITLE
Use assert_match in qpp test

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -20,6 +20,6 @@ class Qpp < Formula
   end
 
   test do
-    system "#{bin}/qpp", "--version"
+    assert_match version.to_s, shell_output("#{bin}/qpp --version")
   end
 end


### PR DESCRIPTION
## Summary
- update qpp formula test to assert the version string

## Testing
- `brew --version` *(fails: command not found)*
- `ruby -c Formula/qpp.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c59d625c00832f8eaa31c6a91fd9ea