### PR TITLE
Fix qpp formula binary installation

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -16,7 +16,8 @@ class Qpp < Formula
   license "Apache-2.0"
 
   def install
-    bin.install "qpp"
+    arch = Hardware::CPU.arm? ? "arm64" : "x64"
+    bin.install "qpp-#{version}-macos-#{arch}" => "qpp"
   end
 
   test do


### PR DESCRIPTION
## Summary
- ensure qpp formula installs the correct architecture-specific binary

## Testing
- `ruby -c Formula/qpp.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c59e42d704832f82dea4d3c533509d