### PR TITLE
Simplify qpp install logic

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -16,17 +16,7 @@ class Qpp < Formula
   license "Apache-2.0"
 
   def install
-    # The release archives contain a single prebuilt binary compressed
-    # with gzip and whose name may vary (e.g. `qpp-0.2.0-macos-arm64`).
-    # Locate the downloaded file, decompress it if needed, and install
-    # it as `qpp` so the executable is always available on the PATH.
-    archive = Dir["qpp*.gz"].first
-    if archive
-      system "gzip", "-d", archive
-      binary = archive.sub(/\.gz\z/, "")
-    else
-      binary = Dir["qpp*"].first
-    end
+    binary = Dir["qpp*"].find { |f| File.file?(f) && !f.end_with?(".gz") }
     bin.install binary => "qpp"
   end
 


### PR DESCRIPTION
## Summary
- Simplify install method to locate unzipped binary dynamically
- Remove manual gzip handling

## Testing
- `brew audit --strict qpp` (fails: command not found)
- `brew install --build-from-source qpp` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c5a8f08214832fbffea048cb010234