### PR TITLE
Handle gz archive when installing qpp

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -17,6 +17,11 @@ class Qpp < Formula
 
   def install
     binary = Dir["qpp*"].find { |f| File.file?(f) && !f.end_with?(".gz") }
+    if binary.nil?
+      gz_file = Dir["qpp*.gz"].first
+      system "gunzip", gz_file
+      binary = gz_file.chomp(".gz")
+    end
     bin.install binary => "qpp"
   end
 


### PR DESCRIPTION
## Summary
- ensure qpp formula extracts gz archive when installing

## Testing
- `brew style Formula/qpp.rb` *(fails: command not found)*
- `ruby -c Formula/qpp.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c5aa9ff770832fa5fb1881bcde7187