### PR TITLE
Handle gzipped binary in qpp formula

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -17,6 +17,9 @@ class Qpp < Formula
 
   def install
     binary = Dir["qpp*"].find { |f| File.file?(f) && !f.end_with?(".gz") }
+    gz_file = Dir["qpp*.gz"].first
+    system "gunzip", gz_file if gz_file
+    binary ||= gz_file ? gz_file.delete_suffix(".gz") : Dir["qpp*"].find { |f| File.file?(f) && !f.end_with?(".gz") }
     bin.install binary => "qpp"
   end
 


### PR DESCRIPTION
## Summary
- expand gzipped release assets before installing qpp binary

## Testing
- `ruby -c Formula/qpp.rb`


------
https://chatgpt.com/codex/tasks/task_e_68c5ae77e1dc832f86494880d651dc6a