### PR TITLE
Handle gzipped binary in qpp formula

### DIFF
--- a/Formula/qpp.rb
+++ b/Formula/qpp.rb
@@ -16,7 +16,10 @@ class Qpp < Formula
   license "Apache-2.0"
 
   def install
-    binary = Dir["qpp*"].find { |f| File.file?(f) && !f.end_with?(".gz") }
+    gz_file = Dir["qpp*.gz"].first
+    system "tar", "-xzf", gz_file if gz_file
+    binary = Dir["**/qpp"].find { |f| File.file?(f) && File.executable?(f) }
+    raise "No qpp binary found" unless binary
     bin.install binary => "qpp"
   end
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# homebrew-qpp
+
+This tap provides the [Q++](https://github.com/sefunmi4/qpp-gcc) compiler and simulator for Homebrew.
+
+## Installation
+
+```bash
+brew tap sefunmi4/qpp
+brew install qpp
+```
+
+The formula automatically extracts the bundled archive and installs the `qpp` binary.
+
+## Usage
+
+After installation, the compiler is available via:
+
+```bash
+qpp --help
+qpp --version
+```
+
+To compile and run a program:
+
+```bash
+qpp path/to/program.qpp
+```


### PR DESCRIPTION
## Summary
- extract tarball within gz archive to access bundled qpp binary
- raise a helpful error when the binary is missing
- document tap usage and installation instructions

## Testing
- `ruby -c Formula/qpp.rb`
- `brew audit --strict qpp` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ae77e1dc832f86494880d651dc6a